### PR TITLE
Modify Menu class, add MenuLogic

### DIFF
--- a/src/main/java/command/MenuAddCommand.java
+++ b/src/main/java/command/MenuAddCommand.java
@@ -1,0 +1,19 @@
+package command;
+
+import model.Menu;
+import model.MenuItem;
+import ui.Parser;
+
+
+public class MenuAddCommand implements MenuCommand {
+    public static Menu execute(Menu newMenu, String inputText) {
+        String[] indexString = Parser.splitInput(Parser.analyzeInput(inputText), inputText);
+        String itemID = indexString[0];
+        String itemName = indexString[1];
+        String itemPrice = indexString[2];
+        //Optional<Menu> item = Menu.getMenuList().get(Integer.parseInt(itemID));
+
+        newMenu.add(new MenuItem(itemID,itemName,Double.parseDouble(itemPrice)));
+        return newMenu;
+    }
+}

--- a/src/main/java/command/MenuCommand.java
+++ b/src/main/java/command/MenuCommand.java
@@ -1,0 +1,4 @@
+package command;
+
+public interface MenuCommand {
+}

--- a/src/main/java/command/MenuHelpCommand.java
+++ b/src/main/java/command/MenuHelpCommand.java
@@ -1,0 +1,14 @@
+package command;
+
+public class MenuHelpCommand implements MenuCommand {
+    public static void execute() {
+        System.out.println("Here are the list of available commands:");
+        System.out.println("\thelp: Shows all the commands that can be used.");
+        System.out.println("\tadd -item <item_id> -name <item_name> -price <price_of_item> : Shows the current menu.");
+        System.out.println("\tdelete -item <item_id> : Shows the current menu.");
+        System.out.println("\tview -menu -all: Shows a list of all the menus of the restaurant");
+        System.out.println("\tview -menu <menu_id>: Shows the items on the specified menu");
+        System.out.println("\tcomplete: Completes the menu and returns to the main menu.");
+        System.out.println("\tbye: Aborts the current menu and returns to the main menu.");
+    }
+}

--- a/src/main/java/logic/MenuLogic.java
+++ b/src/main/java/logic/MenuLogic.java
@@ -1,0 +1,56 @@
+package logic;
+
+import command.MenuAddCommand;
+import command.MenuHelpCommand;
+import command.OrderHelpCommand;
+import model.Menu;
+import ui.CommandType;
+import ui.Parser;
+
+import java.util.Optional;
+import java.util.Scanner;
+
+import static model.Menu.menuList;
+import static ui.CommandType.HELP;
+
+public class MenuLogic {
+    public static Optional<Menu> createNewMenu(Scanner input) {
+        Menu newMenu = new Menu(String.valueOf(Menu.getMenuNum()));
+        boolean isComplete = false;
+        System.out.println("Initializing menu" + newMenu.getID() + "processing...");
+        MenuHelpCommand.execute();
+        while (!isComplete) {
+            String inputText = input.nextLine();
+            CommandType commandType;
+            try {
+                commandType = Parser.analyzeInput(inputText);
+            } catch (IllegalArgumentException e) {
+                System.out.println("Invalid command");
+                continue;
+            }
+            switch(commandType) {
+            case ADD_ITEM:
+                newMenu = MenuAddCommand.execute(newMenu, inputText);
+                break;
+            case DELETE_ITEM:
+                newMenu = MenuDeleteCommand.execute(newMenu, inputText);
+                break;
+            case VIEW_MENU_LIST:
+                MenuViewMenuListCommand.execute();
+                break;
+            case COMPLETE_MENU:
+                isComplete = MenuCompleteCommand.execute(newMenu);
+                break;
+            case HELP:
+                MenuHelpCommand.execute();
+            case EXIT:
+                MenuExitcommand.execute(newMenu);
+                return Optional.empty();
+            default:
+                System.out.println("Invalid command");
+                OrderHelpCommand.execute();
+            }
+        }
+        return Optional.of(newMenu);
+    }
+}

--- a/src/main/java/model/Menu.java
+++ b/src/main/java/model/Menu.java
@@ -16,6 +16,7 @@ import static model.SetMenu.Dinner;
 public class Menu implements ItemManager {
     private static final Logger logr = Logger.getLogger("MenuLogger");
     private final ArrayList<MenuItem> menuItemList = new ArrayList<>();
+    private static final ArrayList<Menu> menuList = new ArrayList<>();
     private final String menuID;
 
     public Menu(String menuID) {
@@ -109,5 +110,13 @@ public class Menu implements ItemManager {
         } catch (java.io.IOException e) {
             logr.log(Level.SEVERE, "File logger not working.",e);
         }
+    }
+
+    public static int getMenuNum() {
+        return menuList.size();
+    }
+
+    public static ArrayList<Menu> getMenuList() {
+        return menuList;
     }
 }

--- a/src/main/java/ui/CommandType.java
+++ b/src/main/java/ui/CommandType.java
@@ -19,7 +19,9 @@ public enum CommandType {
 
     // edit menu commands
     VIEW_MENU("(?i)view menu"),
-    ADD_MENU("(?i)add\\s*-menu");
+    ADD_MENU("(?i)add\\s*-menu"),
+    VIEW_MENU_LIST("(?i)view menu list"),
+    COMPLETE_MENU("(?i)complete\\s*");
 
     private final String commandRegex;
     CommandType(String commandRegex) {


### PR DESCRIPTION
Added Menu Logic. The general idea is that we have a Menu class that has **both** menu item list, to keep track of MenuItems on a single Menu as well as a MenuList which keeps track of multiple menus. In this version, we are implementing the additions of items onto a brand new Menu.

For future versions, we can implement a viewing other menu option or a storage for all unique existing food items so that we can make a new menu by including those as well.

Some of the menu commands were intentionally left unimplemented. (for other members to implement)